### PR TITLE
Install steps copy paste location update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installs of multiple packages are performed sequentially rather than in bulk, so
 
 # Installation
 - sudo su
-- git clone https://github.com/mkrupczak3/Katoolin-Robust.git && cp katoolin/katoolin.py /usr/bin/katoolin
+- git clone https://github.com/mkrupczak3/Katoolin-Robust.git && cp Katoolin-Robust/katoolin.py /usr/bin/katoolin
 - chmod +x /usr/bin/katoolin
 - sudo katoolin
 


### PR DESCRIPTION
The git clone script copies the data into the Katoolin-Robust folder where the python script is located that needs to be copied.